### PR TITLE
[DROOLS-6853] jdk17 compatibility - jaxb dependency

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
@@ -46,6 +46,12 @@
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <!-- Logging -->

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
@@ -93,7 +93,8 @@
         
         <include>xerces:xercesImpl</include>
 
-	<include>com.sun.xml.bind:jaxb-xjc</include>
+        <include>org.glassfish.jaxb:jaxb-runtime</include>
+        <include>org.glassfish.jaxb:jaxb-xjc</include>
 
         <include>org.yaml:snakeyaml</include>
       </includes>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee8-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee8-container.xml
@@ -89,7 +89,8 @@
         
         <include>xerces:xercesImpl</include>
 
-        <include>com.sun.xml.bind:jaxb-xjc</include>
+        <include>org.glassfish.jaxb:jaxb-runtime</include>
+        <include>org.glassfish.jaxb:jaxb-xjc</include>
       </includes>
       <excludes>
         <exclude>org.jboss.resteasy:*</exclude>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-servlet-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-servlet-container.xml
@@ -84,6 +84,9 @@
         <include>org.dom4j:dom4j</include>
         <include>xerces:xercesImpl</include>
 
+        <include>org.glassfish.jaxb:jaxb-runtime</include>
+        <include>org.glassfish.jaxb:jaxb-xjc</include>
+
         <include>jakarta.jms:jakarta.jms-api</include>
 
         <include>org.quartz-scheduler:quartz</include>


### PR DESCRIPTION
- Exclude com.sun.xml.bind:jaxb-impl in test scope to avoid BanDuplicateClasses
- Add glassfish jaxb-runtime and jaxb-xjc in kie-server war